### PR TITLE
WL-4072 Adding properties to make calendar export period configurable

### DIFF
--- a/configuration/bundles/src/bundle/org/sakaiproject/config/bundle/default.sakai.properties
+++ b/configuration/bundles/src/bundle/org/sakaiproject/config/bundle/default.sakai.properties
@@ -1774,6 +1774,10 @@ content.mixedContent.forceLinksInNewWindow=true
 # calendar.external.subscriptions.user.cacheentries=32
 # calendar.external.subscriptions.user.cachetime=120
 
+#Determine the calendar export period
+#calendar.export.previous.months = 6
+#calendar.export.next.months = 12
+
 ## HELP TOOL (helpPath defined in PATHS section above)
 # Comma separated list of tools whose help should not be added to the help index.
 # DEFAULT: none

--- a/configuration/bundles/src/bundle/org/sakaiproject/config/bundle/default.sakai.properties
+++ b/configuration/bundles/src/bundle/org/sakaiproject/config/bundle/default.sakai.properties
@@ -1774,9 +1774,14 @@ content.mixedContent.forceLinksInNewWindow=true
 # calendar.external.subscriptions.user.cacheentries=32
 # calendar.external.subscriptions.user.cachetime=120
 
-#Determine the calendar export period
-#calendar.export.previous.months = 6
-#calendar.export.next.months = 12
+# Determine the range for calendar export
+# Number of months from the past required in the export
+# DEFAULT: 6
+# calendar.export.previous.months = 6
+# Number of months in the future required in the export
+# DEFAULT: 12
+# calendar.export.next.months = 12
+
 
 ## HELP TOOL (helpPath defined in PATHS section above)
 # Comma separated list of tools whose help should not be added to the help index.


### PR DESCRIPTION
calendar.export.previous.months- number of months in past to be included in  export
calendar.export.next.months -  number of months in future to be included in  export
